### PR TITLE
[#5] Don't hide surrounding entry when hiding a code block

### DIFF
--- a/bicycle.el
+++ b/bicycle.el
@@ -185,8 +185,7 @@ has no subsections but it contains code, then skip BRANCHES."
              (progn
                (hs-show-block)
                (outline-show-entry))
-           (hs-hide-block)
-           (outline-hide-entry)))
+           (hs-hide-block)))
         (backward-char))))
      ((save-excursion
         (beginning-of-line 1)


### PR DESCRIPTION
If you remove that `(outline-hide-entry)` call everything seems to behave as expected.