### PR TITLE
If first line of the buffer is empty then cycle-global breaks

### DIFF
--- a/bicycle.el
+++ b/bicycle.el
@@ -128,7 +128,7 @@ Without a prefix argument call `bicycle-cycle-local'."
       (outline-show-all)
       (bicycle--message "ALL"))
      (t
-      (outline-hide-sublevels (bicycle--level))
+      (outline-hide-sublevels (bicycle--top-level))
       (bicycle--message "OVERVIEW")
       (setq this-command 'outline-cycle-overview)))))
 


### PR DESCRIPTION
Hey, I've found another little problem (the one I mentioned in the previous issue but wasn't sure if that's something on my side). 

1. Open an emacs lisp buffer with a bunch of headings
2. Make the first line empty (i.e. insert an empty line in the beginning)
3. bicycle-cycle-global

Instead of switching to normal OVERVIEW it replaces all of the contents of the buffer with `...`.

This is due to this line of code (see the commit): `bicycle-cycle-global` moves the point to the first line of the buffer: `(goto-char (point-min))`, and then in the last section of cond it does `(outline-hide-sublevels (bicycle--level))`. If the first line is empty (or generally speaking not a heading) then `(bicycle--level)` returns a value lower than of any other headings, and thus it hides the whole buffer. Seems like it should rather be `(outline-hide-sublevels (bicycle--top-level))`; it fixes the problem and I didn't notice any other differences.

Keep in mind that it's not visually obvious that something is broken if `reveal-mode` is on.