### PR TITLE
Fix error (outline-before-first-heading)

### DIFF
--- a/bicycle.el
+++ b/bicycle.el
@@ -282,7 +282,12 @@ is not considered to be a sublevel."
           (not (bicycle--non-code-children-p)))
       (outline-show-children level)
     (let ((start-level (funcall outline-level))
-          (eos (save-excursion (outline-end-of-subtree) (point)))
+          (eos (cl-letf (((symbol-function #'outline-back-to-heading)
+                          (lambda (&rest _)
+                            (or (ignore-error outline-before-first-heading
+                                  (progn (outline-back-to-heading) (point)))
+                                (goto-char (point-min))))))
+                 (save-excursion (outline-end-of-subtree) (point))))
           (eoc nil))
       (save-excursion
         (outline-back-to-heading)


### PR DESCRIPTION
I got this backtrace when using `bicycle-outline-cycle` in an .el file lacking an initial `;;; Code:` heading. I am running Emacs 30 with latest Org, and the mentioned advice `outline-back-to-heading@fix-for-org-fold` comes from org-compat.el.

```
Debugger entered--Lisp error: (outline-before-first-heading)
  #<subr outline-back-to-heading>(nil)
  outline-back-to-heading@fix-for-org-fold(#<subr outline-back-to-heading>)
  apply(outline-back-to-heading@fix-for-org-fold #<subr outline-back-to-heading> nil)
  outline-back-to-heading()
  outline-end-of-subtree()
  bicycle-cycle-local()
  bicycle-cycle(nil)
  funcall-interactively(bicycle-cycle nil)
  command-execute(bicycle-cycle)
```

The problem is that `outline-end-of-subtree` calls `outline-back-to-heading` without checking if it is before first heading.

This commit fixes it by having it handle that signal and go to `point-min` as a fallback.